### PR TITLE
Nuke animations (take 2)

### DIFF
--- a/css/component.css
+++ b/css/component.css
@@ -1417,12 +1417,16 @@ perspective effects (not including the modals and the overlay).
 /* Added animation */
 .team,
 .special-services-box, .columns{
-	opacity: 0;
+	/* NUKE THE ANIMATION */
+	opacity: 1;
 }
 
 .zp_start_animation.team,
 .zp_start_animation.special-services-box,
 .zp_start_animation.columns{
+/*
+ * NUKE THE ANIMATION
+ *
 	-webkit-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
 	-moz-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
 	-o-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
@@ -1432,18 +1436,22 @@ perspective effects (not including the modals and the overlay).
 	-webkit-transform:scale(1);
 	-o-transform:scale(1);
 	transform:scale(1);
+ */
 }
 .portfolio_shortcode,
 .zp-grid-wrapper{
-	opacity: 0;
+	/* NUKE THE ANIMATION */
+	opacity: 1;
 }
 .zp_start_animation.portfolio_shortcode,
 .zp_start_animation.zp-grid-wrapper{
+	/* NUKE THE ANIMATION
 	-webkit-animation:zp_fadeUp 1s 1 ;
 	-moz-animation:zp_fadeUp 1s 1;
 	-o-animation:zp_fadeUp 1s 1;
 	animation:zp_fadeUp 1s 1;
 	opacity: 1;
+	*/
 }
 
 .zp_show{

--- a/css/component.css
+++ b/css/component.css
@@ -1427,15 +1427,15 @@ perspective effects (not including the modals and the overlay).
 /*
  * NUKE THE ANIMATION
  *
-	-webkit-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
-	-moz-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
-	-o-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
-	animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
-	opacity:1;
-	-moz-transform:scale(1);
-	-webkit-transform:scale(1);
-	-o-transform:scale(1);
-	transform:scale(1);
+ *	-webkit-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
+ *	-moz-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
+ *	-o-animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
+ *	animation:zp_appear 1s 1 cubic-bezier(0.175, 0.885, 0.320, 1.275);
+ *	opacity:1;
+ *	-moz-transform:scale(1);
+ *	-webkit-transform:scale(1);
+ *	-o-transform:scale(1);
+ *	transform:scale(1);
  */
 }
 .portfolio_shortcode,
@@ -1445,13 +1445,13 @@ perspective effects (not including the modals and the overlay).
 }
 .zp_start_animation.portfolio_shortcode,
 .zp_start_animation.zp-grid-wrapper{
-	/* NUKE THE ANIMATION
-	-webkit-animation:zp_fadeUp 1s 1 ;
-	-moz-animation:zp_fadeUp 1s 1;
-	-o-animation:zp_fadeUp 1s 1;
-	animation:zp_fadeUp 1s 1;
-	opacity: 1;
-	*/
+/* NUKE THE ANIMATION
+ *	-webkit-animation:zp_fadeUp 1s 1 ;
+ *	-moz-animation:zp_fadeUp 1s 1;
+ *	-o-animation:zp_fadeUp 1s 1;
+ *	animation:zp_fadeUp 1s 1;
+ *	opacity: 1;
+ */
 }
 
 .zp_show{

--- a/js/jquery.custom.js
+++ b/js/jquery.custom.js
@@ -206,60 +206,61 @@ jQuery(document).ready(function($) {
 /*-------------------------------------------------------------*/
 //				Element Animation
 /*------------------------------------------------------------*/
-	//return jQuery.waypoints('viewportHeight') - jQuery(this).height() + 100;
-
-	jQuery(' .portfolio_shortcode, .zp-grid-wrapper').waypoint(function() {
-			jQuery(this).addClass('zp_start_animation');
-	}, {
-		offset:'100%'
-	});
-
-	// Animation to service box
-	jQuery('.special-services-box').waypoint(function() {
-		var children = jQuery(".special-services-box");
-		var index = 0;
-
-		function addClassToNextChild() {
-			if (index == children.length) return;
-			children.eq(index++).addClass("zp_start_animation");
-			window.setTimeout(addClassToNextChild, 500);
-		}
-		addClassToNextChild();
-	}, {
-		offset:'100%'
-	});
-
-	// Animation to team box
-	jQuery('.team').waypoint(function() {
-		var children = jQuery(".team");
-		var index = 0;
-
-		function addClassToNextChild() {
-			if (index == children.length) return;
-			children.eq(index++).addClass("zp_start_animation");
-			window.setTimeout(addClassToNextChild, 500);
-		}
-		addClassToNextChild();
-	}, {
-		offset:'100%'
-	});
-
-	//// Animation to Columns
-	jQuery('.columns').waypoint(function() {
-		var children = jQuery(".columns");
-		var index = 0;
-
-		function addClassToNextChild() {
-			if (index == children.length) return;
-			children.eq(index++).addClass("zp_start_animation");
-			window.setTimeout(addClassToNextChild, 500);
-		}
-		addClassToNextChild();
-	}, {
-		offset:'100%'
-	});
-
-
+// NUKE THE ANIMATION
+//	//return jQuery.waypoints('viewportHeight') - jQuery(this).height() + 100;
+//
+//	jQuery(' .portfolio_shortcode, .zp-grid-wrapper').waypoint(function() {
+//			jQuery(this).addClass('zp_start_animation');
+//	}, {
+//		offset:'100%'
+//	});
+//
+//	// Animation to service box
+//	jQuery('.special-services-box').waypoint(function() {
+//		var children = jQuery(".special-services-box");
+//		var index = 0;
+//
+//		function addClassToNextChild() {
+//			if (index == children.length) return;
+//			children.eq(index++).addClass("zp_start_animation");
+//			window.setTimeout(addClassToNextChild, 500);
+//		}
+//		addClassToNextChild();
+//	}, {
+//		offset:'100%'
+//	});
+//
+//	// Animation to team box
+//	jQuery('.team').waypoint(function() {
+//		var children = jQuery(".team");
+//		var index = 0;
+//
+//		function addClassToNextChild() {
+//			if (index == children.length) return;
+//			children.eq(index++).addClass("zp_start_animation");
+//			window.setTimeout(addClassToNextChild, 500);
+//		}
+//		addClassToNextChild();
+//	}, {
+//		offset:'100%'
+//	});
+//
+//	//// Animation to Columns
+//	jQuery('.columns').waypoint(function() {
+//		var children = jQuery(".columns");
+//		var index = 0;
+//
+//		function addClassToNextChild() {
+//			if (index == children.length) return;
+//			children.eq(index++).addClass("zp_start_animation");
+//			window.setTimeout(addClassToNextChild, 500);
+//		}
+//		addClassToNextChild();
+//	}, {
+//		offset:'100%'
+//	});
+//
+// NUKE THE ANIMATIONS END
 
 
 });


### PR DESCRIPTION
- Disable JS responsible for animation
- Set opacity to 1 initially (animation sets it otherwise)
- BONUS: Probably improve loading speed due to missing timeout events  for painting
